### PR TITLE
C2 113

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,39 +4,51 @@ project(m2020_urdf_models)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(gazebo REQUIRED)
+include_directories(${GAZEBO_INCLUDE_DIRS})
 
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   xacro
+  gazebo_ros
 )
 
 
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES attach_model_plugin
-  CATKIN_DEPENDS roscpp xacro
+ INCLUDE_DIRS include
+ LIBRARIES mhs_gazebo_plugin
+  CATKIN_DEPENDS roscpp xacro gazebo_ros
   DEPENDS 
 )
 
-#include_directories(
-# include
-# ${catkin_INCLUDE_DIRS}
-#)
-
-#link_directories(${catkin_LIBRARY_DIRS})
+include_directories(
+include
+${catkin_INCLUDE_DIRS}
+ ${GAZEBO_INCLUDE_DIRS}
 
 
-#install(TARGETS
-#  gazebo_grasp_ui attach_model_plugin move_model_plugin
-#  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-#)
+link_directories(${catkin_LIBRARY_DIRS}))
 
 
-install(DIRECTORY launch 
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+add_library(mhs_gazebo_plugin SHARED src/mhs_gazebo_plugin.cpp)
+target_link_libraries(mhs_gazebo_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+add_dependencies(mhs_gazebo_plugin ${catkin_EXPORTED_TARGETS})
+
+
+install(TARGETS
+  mhs_gazebo_plugin
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,14 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   xacro
   gazebo_ros
+  geometry_msgs
 )
 
 
 catkin_package(
  INCLUDE_DIRS include
  LIBRARIES mhs_gazebo_plugin
-  CATKIN_DEPENDS roscpp xacro gazebo_ros
+  CATKIN_DEPENDS roscpp xacro gazebo_ros geometry_msgs
   DEPENDS 
 )
 

--- a/config/perseverance/perseverance.srdf
+++ b/config/perseverance/perseverance.srdf
@@ -10,15 +10,19 @@
     </group>
 
     <group name="head">
-      <link name="Body_RSM_AZ" />
-      <link name="Body_RSM_EL" />
+      <joint name="RSM_AZ_ENC" />
+      <joint name="RSM_EL_ENC"  />  
     </group>
 
     <group name="camera_chain">
-      <chain base_link="base_footprint" tip_link="kinect_optical_frame" />
+      <chain base_link="base_footprint" tip_link="Body_RSM_EL" />
     </group>
 
-    <end_effector name="camera_ee" parent_link="Body_RSM_AZ" group="head" parent_group="camera_chain" />
+    <end_effector name="camera_ee" parent_link="Body_RSM_EL" group="camera" parent_group="camera_chain" />
+
+    <group name="camera">
+      <link name="Body_RSM_EL" />
+    </group>
 
 
     <!-- Limit joints: AZ_ENC: [0, 6.31] EL_ENC: [0, 3.1765]-->

--- a/config/perseverance/perseverance_navigation.yaml
+++ b/config/perseverance/perseverance_navigation.yaml
@@ -1,6 +1,6 @@
 navigation:
   planning_frame: world
-  robot_frame: /$(arg robot_frame_robot)/base_footprint
+  robot_frame: $(arg robot_frame_robot)/base_footprint
   footsteps: false
   holonomic: false
   nav_planner_plugin: "craftsman_navigation_tools::CraftsmanNavigationPlanner"

--- a/include/m2020_urdf_models/mhs_gazebo_plugin.h
+++ b/include/m2020_urdf_models/mhs_gazebo_plugin.h
@@ -20,36 +20,22 @@ namespace gazebo
 {
   class MHSPlugin : public ModelPlugin
   {
-    /// \brief Constructor
-    public: MHSPlugin();
+    public:
+      MHSPlugin();
 
-    /// \brief Load the model plugin.
-    /// \param[in] _model Pointer to the parent model.
-    /// \param[in] _sdf Pointer to the plugin's SDF elements.
-    public: virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+      virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+      virtual void Reset();
 
-    // Documentation Inherited.
-    public: virtual void Reset();
+    private:
+      void OnUpdate(const common::UpdateInfo &_info);
 
-    /// \brief Function that is called every update cycle.
-    /// \param[in] _info Timing information
-    private: void OnUpdate(const common::UpdateInfo &_info);
+      physics::ModelPtr model_;
+      sdf::ElementPtr sdf;
+      std::vector<event::ConnectionPtr> connections;
+      ignition::math::Vector3d target;
+      ros::Time lastUpdate;
 
-    /// \brief Pointer to the parent model.
-    private: physics::ModelPtr model_;
-
-    /// \brief Pointer to the sdf element.
-    private: sdf::ElementPtr sdf;
-
-    /// \brief List of connections
-    private: std::vector<event::ConnectionPtr> connections;
-
-    /// \brief Current target location
-    private: ignition::math::Vector3d target;
-
-    /// \brief Time of the last update.
-    private: ros::Time lastUpdate;
-
+      std::default_random_engine rgen_;
 
     protected:
       void OnRosVelCmdMsg(const geometry_msgs::TwistConstPtr &_msg);
@@ -58,8 +44,15 @@ namespace gazebo
       std::unique_ptr<ros::NodeHandle> rosNode;
       ros::Subscriber rosVelCmdSub, rosPoseSub;
 
+      std::string robot_namespace_;
+      std::string pose_input_topic_;
+      std::string vel_input_topic_;
+      bool use_pose_input_;
       double blade_vel_;
+      ignition::math::Vector3d xyz_;
+      double noise_;
       double dt_;
+
   };
 }
 #endif

--- a/include/m2020_urdf_models/mhs_gazebo_plugin.h
+++ b/include/m2020_urdf_models/mhs_gazebo_plugin.h
@@ -1,0 +1,68 @@
+
+#ifndef GAZEBO_PLUGINS_MHS_PLUGIN_H_
+#define GAZEBO_PLUGINS_MHS_PLUGIN_H_
+
+#include <string>
+#include <vector>
+#include <random>
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/util/system.hh>
+#include <gazebo/physics/Joint.hh>
+
+#include <gazebo_msgs/SetModelState.h>
+
+namespace gazebo
+{
+  class MHSPlugin : public ModelPlugin
+  {
+    /// \brief Constructor
+    public: MHSPlugin();
+
+    /// \brief Load the model plugin.
+    /// \param[in] _model Pointer to the parent model.
+    /// \param[in] _sdf Pointer to the plugin's SDF elements.
+    public: virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+    // Documentation Inherited.
+    public: virtual void Reset();
+
+    /// \brief Function that is called every update cycle.
+    /// \param[in] _info Timing information
+    private: void OnUpdate(const common::UpdateInfo &_info);
+
+    /// \brief Pointer to the parent model.
+    private: physics::ModelPtr model_;
+
+    /// \brief Pointer to the sdf element.
+    private: sdf::ElementPtr sdf;
+
+    /// \brief List of connections
+    private: std::vector<event::ConnectionPtr> connections;
+
+    /// \brief Current target location
+    private: ignition::math::Vector3d target;
+
+    /// \brief Time of the last update.
+    private: common::Time lastUpdate;
+
+
+    protected:
+      void QueueThread();
+
+      std::unique_ptr<ros::NodeHandle> rosNode;
+
+      /// \brief A ROS callbackqueue that helps process messages
+      ros::CallbackQueue rosQueue;
+
+      /// \brief A thread the keeps running the rosQueue
+      std::thread rosQueueThread;
+
+      double blade_vel_;
+  };
+}
+#endif

--- a/include/m2020_urdf_models/mhs_gazebo_plugin.h
+++ b/include/m2020_urdf_models/mhs_gazebo_plugin.h
@@ -7,14 +7,14 @@
 #include <random>
 
 #include <ros/ros.h>
-#include <ros/callback_queue.h>
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/util/system.hh>
 #include <gazebo/physics/Joint.hh>
 
-#include <gazebo_msgs/SetModelState.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Pose.h>
 
 namespace gazebo
 {
@@ -48,21 +48,18 @@ namespace gazebo
     private: ignition::math::Vector3d target;
 
     /// \brief Time of the last update.
-    private: common::Time lastUpdate;
+    private: ros::Time lastUpdate;
 
 
     protected:
-      void QueueThread();
+      void OnRosVelCmdMsg(const geometry_msgs::TwistConstPtr &_msg);
+      void OnRosPoseCmdMsg(const geometry_msgs::PoseConstPtr &_msg);
 
       std::unique_ptr<ros::NodeHandle> rosNode;
-
-      /// \brief A ROS callbackqueue that helps process messages
-      ros::CallbackQueue rosQueue;
-
-      /// \brief A thread the keeps running the rosQueue
-      std::thread rosQueueThread;
+      ros::Subscriber rosVelCmdSub, rosPoseSub;
 
       double blade_vel_;
+      double dt_;
   };
 }
 #endif

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>roscpp</depend>
   <depend>xacro</depend>
   <depend>gazebo_ros</depend>
+  <depend>geometry_msgs</depend>
 
   <export>
     <gazebo_ros plugin_path="${prefix}/lib" />

--- a/package.xml
+++ b/package.xml
@@ -12,5 +12,10 @@
   
   <depend>roscpp</depend>
   <depend>xacro</depend>
+  <depend>gazebo_ros</depend>
+
+  <export>
+    <gazebo_ros plugin_path="${prefix}/lib" />
+  </export>
 
 </package>

--- a/scripts/blade_spinner.py
+++ b/scripts/blade_spinner.py
@@ -8,15 +8,21 @@ from sensor_msgs.msg import JointState
 
 def BladeSpinner(ns = ""):
 
-    rpm = 2400
-    update_rate = 0.01
-    rad2rev = (2*3.14)
+    blade_inc = 1.1
+
+    update_rate = 0.05
+    blade_inc = 1.1
+
+    # being clever doesnt work as well as we want cause it overloads the JSP.
+    # so lets just be simple and set a fixed inc and a reasonable update rate
+
+    # rpm = 2400
+    # rad2rev = (2.0*3.14)
+    # blade_inc = update_rate*2400*rad2rev/60.0
 
     # rev/min * rad/rev = rad/min
     # rad/min * min/sec = rad/sec
     # rad/sec * sec/inc = rac/inc
-
-    blade_inc = update_rate*2400*rad2rev/60
 
     pub = rospy.Publisher(ns + 'joint_state_controller/joint_command', JointState, queue_size=10)
     rospy.init_node('blade_spinner', anonymous=True)

--- a/scripts/blade_spinner.py
+++ b/scripts/blade_spinner.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+
+import rospy
+import sys
+from sensor_msgs.msg import JointState
+
+
+
+def BladeSpinner(ns = ""):
+
+    rpm = 2400
+    update_rate = 0.01
+    rad2rev = (2*3.14)
+
+    # rev/min * rad/rev = rad/min
+    # rad/min * min/sec = rad/sec
+    # rad/sec * sec/inc = rac/inc
+
+    blade_inc = update_rate*2400*rad2rev/60
+
+    pub = rospy.Publisher(ns + 'joint_state_controller/joint_command', JointState, queue_size=10)
+    rospy.init_node('blade_spinner', anonymous=True)
+    rate = rospy.Rate(1/update_rate)
+
+    js = JointState()
+    js.name = ['MHS_TopBlades_v16', 'MHS_BottomBlades_v16']
+    js.position = [0.0, 0.0]
+
+    while not rospy.is_shutdown():    
+        js.position[0] = js.position[0]+blade_inc
+        js.position[1] = js.position[1]-blade_inc
+
+        if js.position[0] > 3.14 :
+            js.position[0] = -3.14
+
+        if js.position[1] < -3.14 :
+            js.position[1] = 3.14
+
+        pub.publish(js)
+        rate.sleep()
+
+if __name__ == '__main__':
+
+    ns = ""
+    if len(sys.argv) > 1:
+        ns = sys.argv[1] + "/"
+
+    try:
+        BladeSpinner(ns)
+    except rospy.ROSInterruptException:
+        pass
+
+

--- a/src/mhs_gazebo_plugin.cpp
+++ b/src/mhs_gazebo_plugin.cpp
@@ -1,0 +1,89 @@
+#include <m2020_urdf_models/mhs_gazebo_plugin.h>
+
+using namespace gazebo;
+GZ_REGISTER_MODEL_PLUGIN(MHSPlugin)
+
+
+/////////////////////////////////////////////////
+MHSPlugin::MHSPlugin()
+{
+}
+
+/////////////////////////////////////////////////
+void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  this->sdf = _sdf;
+  this->model_ = _model;
+
+  this->rosNode.reset(new ros::NodeHandle("mhs_gazebo_plugin"));
+  
+  this->blade_vel_ = 133.33;
+
+  ROS_WARN_STREAM("************** MHSPlugin " << this->model_->GetName());
+
+  this->connections.push_back(event::Events::ConnectWorldUpdateBegin(
+          std::bind(&MHSPlugin::OnUpdate, this, std::placeholders::_1)));
+
+  this->Reset();
+
+  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_inc_);
+  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_inc_);
+  this->model_->GetJoint("Joint_Leg01_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg02_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg03_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg04_Axis")->SetPosition(0, 0);
+
+  // Initialize ros, if it has not already bee initialized.
+  if (!ros::isInitialized())
+  {
+    int argc = 0;
+    char **argv = NULL;
+    ros::init(argc, argv, "gazebo_client", ros::init_options::NoSigintHandler);
+  }
+
+  // Spin up the queue helper thread.
+  // this->rosQueueThread = std::thread(std::bind(&MHSPlugin::QueueThread, this));  
+
+}
+
+/////////////////////////////////////////////////
+void MHSPlugin::Reset()
+{
+  this->lastUpdate = 0;
+}
+
+
+void MHSPlugin::QueueThread()
+{
+  static const double timeout = 0.01;
+  while (this->rosNode->ok())
+  {
+    this->rosQueue.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+/////////////////////////////////////////////////
+void MHSPlugin::OnUpdate(const common::UpdateInfo &_info)
+{
+  // Time delta
+  double dt = (_info.simTime - this->lastUpdate).Double();
+
+  ignition::math::Pose3d pose = this->model_->WorldPose();
+
+  ROS_INFO_STREAM_THROTTLE(1.0, "MHSPlugin::OnUpdate() -- setting model state for " << this->model_->GetName());
+  ignition::math::Vector3d target_pos(this->x_pos_,0,2.0);
+  ignition::math::Quaterniond target_rot(1.0,0.0,0.0,0.0);
+  target_rot.Normalize();
+  ignition::math::Pose3d target_pose(target_pos,target_rot);
+  this->model_->SetWorldPose(target_pose);
+
+  // set the blades and leg info
+  this->model_->GetJoint("Joint_Leg01_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg02_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg03_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("Joint_Leg04_Axis")->SetPosition(0, 0);
+  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_inc_);
+  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_inc_);
+
+  this->lastUpdate = _info.simTime;
+}

--- a/src/mhs_gazebo_plugin.cpp
+++ b/src/mhs_gazebo_plugin.cpp
@@ -57,6 +57,8 @@ void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   pose_input_topic_ = robot_namespace_ + pose_input_topic_;
   vel_input_topic_ = robot_namespace_ + vel_input_topic_;
 
+  this->model_->SetGravityMode(false);
+
   ROS_INFO_STREAM("=================================");
   ROS_INFO_STREAM("MHSPlugin params");
   ROS_INFO_STREAM("MHSPlugin::xyz: [" << this->xyz_.X() << ", " << this->xyz_.Y() << ", " << this->xyz_.Z() << "]");

--- a/src/mhs_gazebo_plugin.cpp
+++ b/src/mhs_gazebo_plugin.cpp
@@ -26,8 +26,8 @@ void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   this->Reset();
 
-  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_inc_);
-  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_inc_);
+  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_vel_);
+  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_vel_);
   this->model_->GetJoint("Joint_Leg01_Axis")->SetPosition(0, 0);
   this->model_->GetJoint("Joint_Leg02_Axis")->SetPosition(0, 0);
   this->model_->GetJoint("Joint_Leg03_Axis")->SetPosition(0, 0);
@@ -71,7 +71,7 @@ void MHSPlugin::OnUpdate(const common::UpdateInfo &_info)
   ignition::math::Pose3d pose = this->model_->WorldPose();
 
   ROS_INFO_STREAM_THROTTLE(1.0, "MHSPlugin::OnUpdate() -- setting model state for " << this->model_->GetName());
-  ignition::math::Vector3d target_pos(this->x_pos_,0,2.0);
+  ignition::math::Vector3d target_pos(0.0,0,2.0);
   ignition::math::Quaterniond target_rot(1.0,0.0,0.0,0.0);
   target_rot.Normalize();
   ignition::math::Pose3d target_pose(target_pos,target_rot);
@@ -82,8 +82,8 @@ void MHSPlugin::OnUpdate(const common::UpdateInfo &_info)
   this->model_->GetJoint("Joint_Leg02_Axis")->SetPosition(0, 0);
   this->model_->GetJoint("Joint_Leg03_Axis")->SetPosition(0, 0);
   this->model_->GetJoint("Joint_Leg04_Axis")->SetPosition(0, 0);
-  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_inc_);
-  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_inc_);
+  this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_vel_);
+  this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_vel_);
 
   this->lastUpdate = _info.simTime;
 }

--- a/src/mhs_gazebo_plugin.cpp
+++ b/src/mhs_gazebo_plugin.cpp
@@ -17,7 +17,7 @@ void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   this->rosNode.reset(new ros::NodeHandle("mhs_gazebo_plugin"));
   
-  this->blade_vel_ = 133.33;
+  this->blade_vel_ = 251.32;
 
   ROS_WARN_STREAM("************** MHSPlugin " << this->model_->GetName());
 
@@ -25,6 +25,12 @@ void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
           std::bind(&MHSPlugin::OnUpdate, this, std::placeholders::_1)));
 
   this->Reset();
+
+  ignition::math::Vector3d target_pos(0.0,0,2.5);
+  ignition::math::Quaterniond target_rot(1.0,0.0,0.0,0.0);
+  target_rot.Normalize();
+  ignition::math::Pose3d target_pose(target_pos,target_rot);
+  this->model_->SetWorldPose(target_pose);
 
   this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_vel_);
   this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_vel_);
@@ -41,41 +47,109 @@ void MHSPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     ros::init(argc, argv, "gazebo_client", ros::init_options::NoSigintHandler);
   }
 
-  // Spin up the queue helper thread.
-  // this->rosQueueThread = std::thread(std::bind(&MHSPlugin::QueueThread, this));  
+  ROS_WARN_STREAM("************ MHSPlugin() -- subscribing to command topic"); 
 
+  // this->rosVelCmdSub = this->rosNode->subscribe("/base_controller/command", 10,
+                                    // &MHSPlugin::OnRosVelCmdMsg, this);
+
+  this->rosPoseSub = this->rosNode->subscribe("/base_controller/command/pose", 10,
+                                    &MHSPlugin::OnRosPoseCmdMsg, this);
 }
 
 /////////////////////////////////////////////////
 void MHSPlugin::Reset()
 {
-  this->lastUpdate = 0;
+  this->lastUpdate = ros::Time(0);
 }
 
 
-void MHSPlugin::QueueThread()
+/////////////////////////////////////////////////
+void MHSPlugin::OnRosVelCmdMsg(const geometry_msgs::TwistConstPtr &_msg)
 {
-  static const double timeout = 0.01;
-  while (this->rosNode->ok())
+  ROS_INFO_STREAM_THROTTLE(1.0, "MHSPlugin::OnRosVelCmdMsg() -- setting model state for " << this->model_->GetName());
+
+  // Link velocity instantaneously without applying forces
+  // this->model_->SetLinearVel({_msg->linear.x, _msg->linear.y, _msg->linear.z});
+  // this->model_->SetAngularVel({_msg->angular.x, _msg->angular.y, _msg->angular.z});
+
+  ignition::math::Pose3d orig_pose = this->model_->WorldPose();
+  ignition::math::Pose3d new_pose = orig_pose;
+
+  ros::Time now = ros::Time::now();
+  dt_ = (now - this->lastUpdate).toSec();
+
+  double new_x, new_y, new_z, new_roll, new_pitch, new_yaw;
+
+  if (fabs(_msg->linear.x) < 1e-5)
   {
-    this->rosQueue.callAvailable(ros::WallDuration(timeout));
+    new_x = orig_pose.X();
   }
+  else
+  {
+    new_x = orig_pose.X() + _msg->linear.x*dt_;
+  }
+  if (fabs(_msg->linear.y) < 1e-5) 
+  {
+    new_y = orig_pose.Y();
+  }
+  else
+  {
+    new_y = orig_pose.Y() + _msg->linear.y*dt_;
+  }
+  if (fabs(_msg->linear.z) < 1e-5) 
+  {
+    new_z = orig_pose.Z();
+  }
+  else
+  {
+    new_z = orig_pose.Z() + _msg->linear.z*dt_;
+  }
+  if (fabs(_msg->angular.x) < 1e-5)
+  {
+    new_roll = orig_pose.Roll();
+  }
+  else
+  {
+    new_roll = orig_pose.Roll() + _msg->angular.x*dt_;
+  }
+  if (fabs(_msg->angular.y) < 1e-5)
+  {
+    new_pitch = orig_pose.Pitch();
+  }
+  else
+  {
+    new_pitch = orig_pose.Pitch() + _msg->angular.y*dt_;
+  }
+  if (fabs(_msg->angular.z) < 1e-5)
+  {
+    new_yaw = orig_pose.Yaw();
+  }
+  else
+  {
+    new_yaw = orig_pose.Yaw() + _msg->angular.z*dt_;
+  }
+
+  new_pose.Set(new_x, new_y, new_z, new_roll, new_pitch, new_yaw);
+  ignition::math::Pose3d target_pose(new_pose);
+  this->model_->SetWorldPose(target_pose);
+  this->lastUpdate = now;
+}
+
+/////////////////////////////////////////////////
+void MHSPlugin::OnRosPoseCmdMsg(const geometry_msgs::PoseConstPtr &_msg)
+{
+  ROS_INFO_STREAM_THROTTLE(1.0, "MHSPlugin::OnRosPoseCmdMsg() -- setting model state for " << this->model_->GetName());
+  ignition::math::Vector3d target_pos(_msg->position.x,_msg->position.y,_msg->position.z);
+  ignition::math::Quaterniond target_rot(_msg->orientation.w,_msg->orientation.x,_msg->orientation.y,_msg->orientation.z);
+  target_rot.Normalize();
+  ignition::math::Pose3d target_pose(target_pos,target_rot);
+  this->model_->SetWorldPose(target_pose);
 }
 
 /////////////////////////////////////////////////
 void MHSPlugin::OnUpdate(const common::UpdateInfo &_info)
 {
-  // Time delta
-  double dt = (_info.simTime - this->lastUpdate).Double();
-
   ignition::math::Pose3d pose = this->model_->WorldPose();
-
-  ROS_INFO_STREAM_THROTTLE(1.0, "MHSPlugin::OnUpdate() -- setting model state for " << this->model_->GetName());
-  ignition::math::Vector3d target_pos(0.0,0,2.0);
-  ignition::math::Quaterniond target_rot(1.0,0.0,0.0,0.0);
-  target_rot.Normalize();
-  ignition::math::Pose3d target_pose(target_pos,target_rot);
-  this->model_->SetWorldPose(target_pose);
 
   // set the blades and leg info
   this->model_->GetJoint("Joint_Leg01_Axis")->SetPosition(0, 0);
@@ -84,6 +158,4 @@ void MHSPlugin::OnUpdate(const common::UpdateInfo &_info)
   this->model_->GetJoint("Joint_Leg04_Axis")->SetPosition(0, 0);
   this->model_->GetJoint("MHS_TopBlades_v16")->SetVelocity(0, blade_vel_);
   this->model_->GetJoint("MHS_BottomBlades_v16")->SetVelocity(0, -blade_vel_);
-
-  this->lastUpdate = _info.simTime;
 }

--- a/urdf/gazebo/mhs.gazebo.component_macros.xacro
+++ b/urdf/gazebo/mhs.gazebo.component_macros.xacro
@@ -75,12 +75,16 @@
     <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_Leg04_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
 
 
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="MHS_TopBlades_v16" kd="0" kp="1"/>
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="MHS_BottomBlades_v16" kd="0" kp="1"/>
     <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg01_Axis" kd="0" kp="1"/>
     <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg02_Axis" kd="0" kp="1"/>
     <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg03_Axis" kd="0" kp="1"/>
     <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg04_Axis" kd="0" kp="1"/>
 
 
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="MHS_TopBlades_v16" reduction="1" tc="1"/>
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="MHS_BottomBlades_v16" reduction="1" tc="1"/>
     <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg01_Axis" reduction="1" tc="1"/>
     <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg02_Axis" reduction="1" tc="1"/>
     <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg03_Axis" reduction="1" tc="1"/>

--- a/urdf/gazebo/mhs.gazebo.component_macros.xacro
+++ b/urdf/gazebo/mhs.gazebo.component_macros.xacro
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- link xacro -->
+  <xacro:macro name="gazebo_link" params="prefix link_name gravity_off static collide">
+    <gazebo reference="${prefix}${link_name}">
+      <selfCollide>${collide}</selfCollide>
+      <static>${static}</static>
+      <turnGravityOff>${gravity_off}</turnGravityOff>
+   </gazebo>
+  </xacro:macro>
+
+  <!-- joint xacro -->
+  <xacro:macro name="gazebo_joint" params="prefix joint_name kd kp">
+     <gazebo reference="${prefix}${joint_name}">
+        <stopKd value="${kd}"/> 
+        <stopKp value="${kp}"/> 
+        <implicitSpringDamper>1</implicitSpringDamper>
+     </gazebo>
+  </xacro:macro>
+
+  <!-- transmission xacro -->
+  <xacro:macro name="gazebo_simple_pos_trans" params="prefix joint_name reduction tc">
+     <transmission name="${prefix}${joint_name}_trans">
+       <type>transmission_interface/SimpleTransmission</type>
+       <joint name="${prefix}${joint_name}">
+         <hardwareInterface>PositionJointInterface</hardwareInterface>
+       </joint>
+       <actuator name="${prefix}${joint_name}_motor">
+         <hardwareInterface>PositionJointInterface</hardwareInterface>
+         <mechanicalReduction>${reduction}</mechanicalReduction>
+       </actuator>
+       <motorTorqueConstant>${tc}</motorTorqueConstant>
+     </transmission>
+  </xacro:macro>
+
+  <xacro:macro name="gazebo_simple_trans" params="prefix joint_name reduction tc">
+      <transmission name="${prefix}${joint_name}_trans">
+       <type>transmission_interface/SimpleTransmission</type>
+       <joint name="${prefix}${joint_name}">
+         <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+       </joint>
+       <actuator name="${prefix}${joint_name}_motor">
+         <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+         <mechanicalReduction>${reduction}</mechanicalReduction>
+       </actuator>
+       <motorTorqueConstant>${tc}</motorTorqueConstant>
+     </transmission>
+
+  </xacro:macro>
+
+  <xacro:macro name="gazebo_dif_drive_trans" params="prefix joint_name reduction tc">
+     <transmission name="${prefix}${joint_name}_trans">
+       <type>transmission_interface/DifferentialTransmission</type>
+       <joint name="${prefix}${joint_name}">
+         <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+       </joint>
+       <actuator name="${prefix}${joint_name}_motor">
+         <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+         <mechanicalReduction>${reduction}</mechanicalReduction>
+       </actuator>
+       <motorTorqueConstant>${tc}</motorTorqueConstant>
+     </transmission>
+  </xacro:macro>
+
+
+
+   <!-- head xacro -->
+  <xacro:macro name="mhs" params="prefix static:=false gravity_off:=true">
+
+    <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_MainBody_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
+    <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_Leg01_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
+    <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_Leg02_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
+    <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_Leg03_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
+    <xacro:gazebo_link prefix="${prefix}" link_name="Body_MHS_Leg04_v16" collide="true" static="${static}" gravity_off="${gravity_off}"/>
+
+
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg01_Axis" kd="0" kp="1"/>
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg02_Axis" kd="0" kp="1"/>
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg03_Axis" kd="0" kp="1"/>
+    <xacro:gazebo_joint prefix="${prefix}" joint_name="Joint_Leg04_Axis" kd="0" kp="1"/>
+
+
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg01_Axis" reduction="1" tc="1"/>
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg02_Axis" reduction="1" tc="1"/>
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg03_Axis" reduction="1" tc="1"/>
+    <xacro:gazebo_simple_trans prefix="${prefix}" joint_name="Joint_Leg04_Axis" reduction="1" tc="1"/>
+
+  </xacro:macro>
+
+
+  <!-- kinect xacro -->
+  <xacro:macro name="kinect_gazebo" params="prefix"/>
+  
+ 
+  <!-- tracbot hokuyo xacro    -->
+  <!--<xacro:macro name="hokuyo_gazebo" params="prefix"/>-->
+
+
+</robot>
+
+

--- a/urdf/gazebo/mhs.gazebo.components.xacro
+++ b/urdf/gazebo/mhs.gazebo.components.xacro
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<robot name="ingenuity" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="mhs_gazebo_components"  params="robot_namespace:='' ">
+
+    <xacro:include filename="$(find m2020_urdf_models)/urdf/gazebo/mhs.gazebo.component_macros.xacro" />
+  
+    <xacro:include filename="$(find m2020_urdf_models)/urdf/gazebo/kinect.gazebo.xacro"/>
+    <xacro:include filename="$(find m2020_urdf_models)/urdf/gazebo/kinect.urdf.xacro"/>
+
+    <!-- build components -->
+    <xacro:mhs prefix="" />
+
+    <xacro:kinect prefix="" parent="Frame_MHS_NAVCAM"/>
+    <xacro:kinect_gazebo prefix="" robot_namespace="${robot_namespace}"/>
+
+  </xacro:macro>
+
+</robot>
+
+

--- a/urdf/gazebo/mhs.gazebo.controllers.xacro
+++ b/urdf/gazebo/mhs.gazebo.controllers.xacro
@@ -15,6 +15,13 @@
     <gazebo>
       <plugin name="mhs_gazebo_plugin" filename="libmhs_gazebo_plugin.so">
         <robotSimType>m2020_urdf_models/MHSPlugin</robotSimType>
+        <bladeVel>251.32</bladeVel>
+        <usePoseInput>true</usePoseInput>
+        <poseInputTopic>/base_controller/command/pose_cmd</poseInputTopic>
+        <velInputTopic>/base_controller/command</velInputTopic>
+        <robotNamespace>${robot_namespace}</robotNamespace>
+        <xyz>0.0 -2.0 2.5</xyz>
+        <noise>0.0001</noise>
       </plugin>
     </gazebo>
 

--- a/urdf/gazebo/mhs.gazebo.controllers.xacro
+++ b/urdf/gazebo/mhs.gazebo.controllers.xacro
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="mhs_gazebo_ros_control"  params="robot_namespace:='' ">
+
+    <gazebo>
+      <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+        <robotNamespace>${robot_namespace}</robotNamespace>
+        <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+        <robotParam>robot_description</robotParam>
+        <legacyModeNS>true</legacyModeNS>
+      </plugin>
+    </gazebo>
+    
+    <gazebo>
+      <plugin name="mhs_gazebo_plugin" filename="libmhs_gazebo_plugin.so">
+        <robotSimType>m2020_urdf_models/MHSPlugin</robotSimType>
+      </plugin>
+    </gazebo>
+
+  </xacro:macro>  
+</robot>

--- a/urdf/mhs.sim.urdf.xacro
+++ b/urdf/mhs.sim.urdf.xacro
@@ -1,0 +1,150 @@
+<?xml version="1.0" ?>
+
+<robot name="ingenuity" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:arg name="robot_namespace" default="" />
+
+  <!--<xacro:property name="robot_name" value="ingenuity" />-->
+  <xacro:property name="mu1" value="100.0"/>
+  <xacro:property name="mu2" value="100.0"/>
+
+  <xacro:include filename="$(find m2020_urdf_models)/urdf/mhs.urdf.xacro" />
+  <xacro:include filename="$(find m2020_urdf_models)/urdf/gazebo/mhs.gazebo.components.xacro" />
+  <xacro:include filename="$(find m2020_urdf_models)/urdf/gazebo/mhs.gazebo.controllers.xacro" />
+
+  <xacro:mhs_gazebo_components robot_namespace="$(arg robot_namespace)"/>
+  <xacro:mhs_gazebo_ros_control robot_namespace="$(arg robot_namespace)"/>
+  
+  
+  <gazebo reference="root">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <fdir1>1 0 0</fdir1>
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_MainBody_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <fdir1>1 0 0</fdir1>
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_TopBlades_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_BottomBlades_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_Joint_Leg02_Axis">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_Leg02_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+
+  <gazebo reference="Body_Joint_Leg01_Axis">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_Leg01_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_Joint_Leg03_Axis">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_Leg03_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_Joint_Leg04_Axis">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Body_MHS_Leg04_v16">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+  <gazebo reference="Frame_MHS_NAVCAM">
+    <kp>1000000.0</kp>
+    <kd>100.0</kd>
+    <mu1>${mu1}</mu1>
+    <mu2>${mu2}</mu2>
+    <!-- <fdir1>1 0 0</fdir1 -->
+    <maxVel>1.0</maxVel>
+    <minDepth>0.01</minDepth>
+  </gazebo>
+
+</robot>

--- a/urdf/mhs.urdf.xacro
+++ b/urdf/mhs.urdf.xacro
@@ -27,9 +27,9 @@
 		</visual>
 		<collision name="ColGeom_MHS_MainBody_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-<!--       <geometry>
-        <box size="1.22 1.22 0.55" />
-      </geometry> -->
+      <!-- <geometry> -->
+        <!-- <box size="1.22 1.22 0.55" /> -->
+      <!-- </geometry> -->
 			<geometry>
 				<mesh filename="package://m2020_urdf_models/mhs/meshes/MHS_MainBody_v16.dae" scale="1 1 1"/>
 			</geometry>

--- a/urdf/mhs.urdf.xacro
+++ b/urdf/mhs.urdf.xacro
@@ -9,15 +9,15 @@
 	<link name="root">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 	</link>
 	<link name="Body_MHS_MainBody_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="10"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_MainBody_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -27,16 +27,19 @@
 		</visual>
 		<collision name="ColGeom_MHS_MainBody_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-      <geometry>
+<!--       <geometry>
         <box size="1.22 1.22 0.55" />
-      </geometry>
+      </geometry> -->
+			<geometry>
+				<mesh filename="package://m2020_urdf_models/mhs/meshes/MHS_MainBody_v16.dae" scale="1 1 1"/>
+			</geometry>
 		</collision>
 	</link>
 	<link name="Body_MHS_TopBlades_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_TopBlades_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -48,8 +51,8 @@
 	<link name="Body_MHS_BottomBlades_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_BottomBlades_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -61,15 +64,15 @@
 	<link name="Body_Joint_Leg02_Axis">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 	</link>
 	<link name="Body_MHS_Leg02_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_Leg02_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -87,15 +90,15 @@
 	<link name="Body_Joint_Leg01_Axis">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 	</link>
 	<link name="Body_MHS_Leg01_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_Leg01_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -113,15 +116,15 @@
 	<link name="Body_Joint_Leg03_Axis">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 	</link>
 	<link name="Body_MHS_Leg03_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_Leg03_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -139,15 +142,15 @@
 	<link name="Body_Joint_Leg04_Axis">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 	</link>
 	<link name="Body_MHS_Leg04_v16">
 		<inertial>
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
-			<mass value="0"/>
-			<inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+			<mass value="0.1"/>
+			<inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
 		</inertial>
 		<visual name="VisGeom_MHS_Leg04_v16">
 			<origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -168,19 +171,19 @@
 		<parent link="root"/>
 		<child link="Body_MHS_MainBody_v16"/>
 	</joint>
-	<joint name="MHS_TopBlades_v16" type="revolute">
+	<joint name="MHS_TopBlades_v16" type="continuous">
 		<origin xyz="0 0 0" rpy="0 -0 0"/>
 		<parent link="Body_MHS_MainBody_v16"/>
 		<child link="Body_MHS_TopBlades_v16"/>
 		<axis xyz="0 0 1"/>
-		<limit lower="-1.79769e+308" upper="1.79769e+308" effort="1.79769e+308" velocity="1.79769e+308"/>
+		<limit effort="1.79769e+308" velocity="1.79769e+308"/>
 	</joint>
-	<joint name="MHS_BottomBlades_v16" type="revolute">
+	<joint name="MHS_BottomBlades_v16" type="continuous">
 		<origin xyz="0 0 0" rpy="0 -0 0.994839"/>
 		<parent link="Body_MHS_MainBody_v16"/>
 		<child link="Body_MHS_BottomBlades_v16"/>
 		<axis xyz="0 0 1"/>
-		<limit lower="-1.79769e+308" upper="1.79769e+308" effort="1.79769e+308" velocity="1.79769e+308"/>
+		<limit effort="1.79769e+308" velocity="1.79769e+308"/>
 	</joint>
 	<joint name="Joint_Leg02_Axis" type="revolute">
 		<origin xyz="-0.0799965 -0.0899998 0.013566" rpy="-0.0338305 -0.721918 0.0511692"/>


### PR DESCRIPTION
This PR adds gazebo support for mhs/ingenuity.  It includes a plugin for spinning the blades and allowing input commands while "maintaining" the desired position (rather than relying on gazebo physics). 

The plugin, located in **mhs.gazebo.controllers** can be configured as follows: 
```
 <gazebo>
      <plugin name="mhs_gazebo_plugin" filename="libmhs_gazebo_plugin.so">
        <robotSimType>m2020_urdf_models/MHSPlugin</robotSimType>
        <bladeVel>251.32</bladeVel>
        <usePoseInput>true</usePoseInput>
        <poseInputTopic>/base_controller/command/pose_cmd</poseInputTopic>
        <velInputTopic>/base_controller/command</velInputTopic>
        <robotNamespace>${robot_namespace}</robotNamespace>
        <xyz>0.0 -2.0 2.5</xyz>
        <noise>0.0001</noise>
      </plugin>
    </gazebo>
```

If you set **usePoseInput** to true, it will take input positions from the **poseInputTopic**, and set the robot accordingly. if you set this param to false, it will use input twists/velocities from the **velInputTopic**.  In practice, the pose approach was working better, but i'm allowing both in case we want to make the vel approach work better in the future.

**noise** adds some "realiism" to the robot, so we just tweak its position by some random noise with this variance every update.  

**bladeVel** is rad/s.

For RViz simulation of ingenuity, there is a new **blade_spinner.py** node that you can run as well (currently less configurable, just tweak the python....).